### PR TITLE
Add .gitattributes file to ignore paths when exporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# This way, the files would be available in the repository but it would not be downloaded when the package is required by another project.
+/.clang-format          export-ignore
+/.clang-format-ignore   export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.github                export-ignore
+/tests                  export-ignore


### PR DESCRIPTION
Create a `.gitattributes` file, and add paths with the `export-ignore` flag set, so they're not pulled down as part of a project's dependencies via Composer.