### PR TITLE
Fix it so CI runs on branches with '/' in name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches:
-      - '*'
-      - '!main'
+    branches-ignore:
+      - 'main'
 
 env:
   BUILDER_VERSION: v0.8.18


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
