### PR TITLE
Fix deprecated use of ${var} in Encoding.php

### DIFF
--- a/src/AWS/CRT/Internal/Encoding.php
+++ b/src/AWS/CRT/Internal/Encoding.php
@@ -24,7 +24,7 @@ final class Encoding {
     public static function decodeString($buffer) {
         $len = unpack("N", $buffer)[1];
         $buffer = substr($buffer, 4);
-        $str = unpack("a${len}", $buffer)[1];
+        $str = unpack("a{$len}", $buffer)[1];
         return [$len, $str];
     }
 


### PR DESCRIPTION
Since PHP 8.2 the syntax "${var}" is deprecated.
"{$var}" should be used instead.

*Issue #, if available:* #105

*Description of changes:*
Changing `"a${len}"` to `"a{$len}"` works the same as before but doesn't use the ${var} syntax deprecated in PHP 8.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
