### PR TITLE
aws-crt-ffi v0.3.7 -> v0.3.8

### DIFF
--- a/ext/php_aws_crt.h
+++ b/ext/php_aws_crt.h
@@ -17,8 +17,8 @@
 
 #include <aws/common/common.h>
 #include <aws/common/mutex.h>
-#include <aws/common/promise.h>
 #include <aws/common/thread.h>
+#include <aws/io/future.h>
 
 /* ZEND_EXTENSION_API_NO from each branch of the PHP source */
 #define AWS_PHP_EXTENSION_API_5_5 220121212
@@ -162,8 +162,8 @@ bool aws_php_thread_queue_drain(aws_php_thread_queue *queue);
 /* called from worker thread to wait for the main thread to execute any queued work in PHP */
 void aws_php_thread_queue_yield(aws_php_thread_queue *queue);
 
-/* called from PHP thread to wait on async queued jobs, one of which MUST complete the promise */
-void aws_php_thread_queue_wait(aws_php_thread_queue *queue, struct aws_promise *promise);
+/* called from PHP thread to wait on async queued jobs, one of which MUST complete the future */
+void aws_php_thread_queue_wait(aws_php_thread_queue *queue, struct aws_future_void *future);
 
 /**
  * generic dispatch mechanism to call a callback provided as a zval with arguments


### PR DESCRIPTION
Also: replace uses of `aws_promise` (removed in https://github.com/awslabs/aws-c-common/pull/1110) with `aws_future`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
