### PR TITLE
Fix segfaults -- CRC64NVME on machines with disabled AVX and uri parsing corner case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
       run: |
         phpize
         ./configure
+        export PHP_EXECUTABLE=$(which php)
+        php --version
         make
         ./dev-scripts/run_tests.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,6 @@ jobs:
       run: |
         phpize
         ./configure
-        export PHP_EXECUTABLE=$(which php)
-        php --version
         make
         ./dev-scripts/run_tests.sh
 

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,7 +1,7 @@
 
 INT_DIR=$(builddir)/build/install
 CMAKE_BUILD_DIR=$(builddir)/cmake_build
-GENERATE_STUBS=$(shell expr `$(PHP_EXECUTABLE) --version | head -1 | cut -f 2 -d' '` \>= 7.1)
+GENERATE_STUBS=$(shell expr `php --version | head -1 | cut -f 2 -d' '` \>= 7.1)
 
 CMAKE = cmake3
 ifeq (, $(shell which cmake3))
@@ -63,13 +63,13 @@ $(builddir)/ext/awscrt.c: $(CMAKE_BUILD_DIR)/aws-crt-ffi-static/libaws-crt-ffi.a
 $(srcdir)/ext/awscrt_arginfo.h: $(srcdir)/ext/awscrt.stub.php $(srcdir)/gen_stub.php
 ifeq ($(GENERATE_STUBS),1)
 	# generate awscrt_arginfo.h
-	$(PHP_EXECUTABLE) $(srcdir)/gen_stub.php --minimal-arginfo $(srcdir)/ext/awscrt.stub.php
+	php $(srcdir)/gen_stub.php --minimal-arginfo $(srcdir)/ext/awscrt.stub.php
 endif
 
 # transform/install api.h from FFI lib
 $(srcdir)/ext/api.h: $(srcdir)/crt/aws-crt-ffi/src/api.h
 	# generate api.h
-	$(PHP_EXECUTABLE) $(srcdir)/gen_api.php $(srcdir)/crt/aws-crt-ffi/src/api.h > $(srcdir)/ext/api.h
+	php $(srcdir)/gen_api.php $(srcdir)/crt/aws-crt-ffi/src/api.h > $(srcdir)/ext/api.h
 
 # install api.h to ext/ as well
 $(builddir)/ext/api.h : $(srcdir)/ext/api.h


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pick up change from
https://github.com/awslabs/aws-crt-ffi/pull/77

- Major changes we pull in from submodules:
  - https://github.com/awslabs/aws-c-common/pull/1185 -- fix heap overflow on uri parsing
  - https://github.com/awslabs/aws-c-common/pull/1182 -- Fix CRC64NVME crash on machines with disabled AVX
  - https://github.com/awslabs/aws-c-auth/pull/261

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
